### PR TITLE
Fix CEF annd CNP with new version Jaguar2 Report

### DIFF
--- a/dotnet-jaguarportal/Jaguar2/Models/Jaguar2Model.cs
+++ b/dotnet-jaguarportal/Jaguar2/Models/Jaguar2Model.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 
 namespace dotnet_jaguarportal.Jaguar2.Models
 {
-
     // NOTE: Generated code may require at least .NET Framework 4.5 or .NET Core/Standard 2.0.
     /// <remarks/>
     [System.SerializableAttribute()]
@@ -29,6 +28,22 @@ namespace dotnet_jaguarportal.Jaguar2.Models
             set
             {
                 this.packageField = value;
+            }
+        }
+
+        private reportTests testsField;
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute("tests")]
+        public reportTests tests
+        {
+            get
+            {
+                return this.testsField;
+            }
+            set
+            {
+                this.testsField = value;
             }
         }
     }
@@ -213,6 +228,48 @@ namespace dotnet_jaguarportal.Jaguar2.Models
             set
             {
                 this.suspField = value;
+            }
+        }
+    }
+
+
+
+    /// <remarks/>
+    [System.SerializableAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true)]
+    public partial class reportTests
+    {
+
+        private byte failField;
+
+        private byte passField;
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public byte fail
+        {
+            get
+            {
+                return this.failField;
+            }
+            set
+            {
+                this.failField = value;
+            }
+        }
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public byte pass
+        {
+            get
+            {
+                return this.passField;
+            }
+            set
+            {
+                this.passField = value;
             }
         }
     }

--- a/dotnet-jaguarportal/Jaguar2/Services/Jaguar2Converter.cs
+++ b/dotnet-jaguarportal/Jaguar2/Services/Jaguar2Converter.cs
@@ -3,6 +3,7 @@ using dotnet_jaguarportal.Jaguar2.Models;
 using dotnet_jaguarportal.JaguarPortal.Models;
 using Microsoft.Extensions.Logging;
 using System.Reflection.Metadata.Ecma335;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace dotnet_jaguarportal.Jaguar2.Services
 {
@@ -55,10 +56,10 @@ namespace dotnet_jaguarportal.Jaguar2.Services
                         {
                             myClass.Lines.Add(new LineAnalysisModel()
                             {
-                                Cef = line.cef,
+                                Cef = model.tests.fail - line.cef,
                                 Cep = line.cep,
                                 Cnf = line.cnf,
-                                Cnp = line.cnp,
+                                Cnp = model.tests.pass - line.cep,
                                 NumberLine = line.nr,
                                 SuspiciousValue = double.Parse(line.susp.ToString()),
                                 Method = getMethod(item.name, line.nr)


### PR DESCRIPTION
In Jaguar2 pull request 59 (https://github.com/saeg/jaguar2/pull/59), CNF and CNP were removed. So now we will calculate as below:

```
CNF = tests.fail - line.cef
CNP = tests.pass - line.cep
```