### PR TITLE
Fix parameter name --prRepository to --prRepo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,14 +73,14 @@ if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
     # JaguarPortal parameters: https://github.com/ericksonlbs/JaguarPortal/wiki/API-Documentation/
     # prKey	                Unique identifier of your PR. Must correspond to the key of the PR in GitHub or TFS. E.G.: 5
     # prBranch	            The name of your PR Ex: feature/my-new-feature
-    # prBase	                The long-lived branch into which the PR will be merged. Default: master E.G.: master
-    # prRepository	SLUG of the GitHub Repo (owner/repo)
+    # prBase	            The long-lived branch into which the PR will be merged. Default: master E.G.: master
+    # prRepo                SLUG of the GitHub Repo (owner/repo)
 
     # Extract Pull Request numer from the GITHUB_REF variable
     PR_NUMBER=$(echo "$GITHUB_REF" | awk 'BEGIN { FS = "/" } ; { print $3 }')
 
     # Add pull request specific parameters
-    jaguarportal_cmd="$jaguarportal_cmd --prKey=$PR_NUMBER --prBranch=$GITHUB_HEAD_REF --prBase=$GITHUB_BASE_REF --prRepository=$GITHUB_REPOSITORY --prProvider=github"
+    jaguarportal_cmd="$jaguarportal_cmd --prKey=$PR_NUMBER --prBranch=$GITHUB_HEAD_REF --prBase=$GITHUB_BASE_REF --prRepo=$GITHUB_REPOSITORY --prProvider=github"
 
 fi
 


### PR DESCRIPTION
Fix parameter name --prRepository to --prRepo, same as command line.